### PR TITLE
fix error in IOS devices, reset starts when focus out.

### DIFF
--- a/angular-input-stars.js
+++ b/angular-input-stars.js
@@ -7,7 +7,7 @@ angular.module('angular-input-stars', [])
             restrict: 'EA',
             replace: true,
             template: '<ul ng-class="listClass">' +
-            '<li ng-mouseenter="paintStars($index)" ng-mouseleave="unpaintStars($index)" ng-repeat="item in items track by $index">' +
+            '<li ng-touch="paintStars($index)" ng-mouseleave="unpaintStars($index)" ng-repeat="item in items track by $index">' +
             '<i  ng-class="getClass($index)" ng-click="setValue($index, $event)"></i>' +
             '</li>' +
             '</ul>',


### PR DESCRIPTION
In safari on ipad when touch over the stars and click over other input, stars reset
