### PR TITLE
readme.md: hint for setting the 'readonly' attribute conditionally

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,10 @@ You can make it readonly thanks to [@anjorinjnr](https://github.com/anjorinjnr)
 	<input-stars max="10" list-class="shiny-list" ng-model="YourCtrl.property" readonly="true" ></input-stars>
 	<input-stars max="10" list-class="shiny-list" ng-model="YourCtrl.property" readonly="readonly" ></input-stars>
 ```
+Use ng-attr to conditionally set the **readonly** attribute
+```html
+	<input-stars max="10" list-class="shiny-list" ng-model="YourCtrl.property" ng-attr-readonly="{{YourCtrl.isDisabled ? 'true' : undefined}}" ></input-stars>
+```
 
 > The .css file is optional and it is a bootstrap for customizations.
 


### PR DESCRIPTION
Instruction for setting the 'readonly' attribute conditionally added.
I've spent some time figuring out how to make the readonly mode depend on my scope variable. The difficulty was in the 'readonly' attribute which ignores the attribute's value, it just should be present or absent. As it turns out, ng-attr directive allows to omit an attribute if 'undefined' is passed to it.
